### PR TITLE
Updates home-manager options

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -100,21 +100,16 @@ in {
 
       systemd.user.services = {
         battery-notifier = {
-          Unit = {
-            Description = "A very useful battery notifier for window managers";
-          };
+            description = "A very useful battery notifier for window managers";
 
-          Service = {
+          serviceConfig = {
             Type = "simple";
             ExecStart = let
               pname = "battery-notifier";
             in "${flake-pkgs.battery-notifier}/bin/${pname} --config-file=${tomlFormat.generate "${pname}-user-config" cfg.settings}";
             Restart = "on-failure";
           };
-
-          Install = {
-            WantedBy = ["default.target"];
-          };
+            wantedBy = ["default.target"];
         };
       };
     };


### PR DESCRIPTION
It is not possible to use the home-manager module due to inconsistencies between the options specified in [Nix Search Options](https://search.nixos.org/options?channel=23.11&show=systemd.user.services.%3Cname%3E.wantedBy&from=0&size=50&sort=relevance&type=packages&query=systemd.user.services.%3Cname%3E) and the options specified at the home-manager module code.

```bash
error:
       … while calling the 'head' builtin

         at /nix/store/c5s2dk74q09f7nzpq0j93cqjfn96q08d-source/lib/attrsets.nix:1541:11:

         1540|         || pred here (elemAt values 1) (head values) then
         1541|           head values
             |           ^
         1542|         else

       … while evaluating the attribute 'value'

         at /nix/store/c5s2dk74q09f7nzpq0j93cqjfn96q08d-source/lib/modules.nix:809:9:

          808|     in warnDeprecation opt //
          809|       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
             |         ^
          810|         inherit (res.defsFinal') highestPrio;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: The option `systemd.user.services.battery-notifier.Install' does not exist. Definition values:
       - In `/nix/store/c5s2dk74q09f7nzpq0j93cqjfn96q08d-source/flake.nix':
           {
             WantedBy = [
               "default.target"
             ];
           }
```

 So I changed the module as little as possible so that it would work again! :)